### PR TITLE
allow the 2.9 stable sdk and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-# Changelog
+## 1.1.0-nullsafety.1
+
+* Allow the 2.9.x stable sdk.
 
 ## 1.1.0-nullsafety
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.1.0-nullsafety.1
 
-* Allow the 2.9.x stable sdk.
+* Allow the <=2.9.10 stable sdks.
 
 ## 1.1.0-nullsafety
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,11 @@
 name: characters
-version: 1.1.0-nullsafety
+version: 1.1.0-nullsafety.1
 description: String replacement with operations that are Unicode/grapheme cluster aware.
 homepage: https://www.github.com/dart-lang/characters
 
 environment:
-  # This must remain a tight constraint (only allow dev versions) until nnbd is
-  # stable.
-  sdk: '>=2.9.0-18.0 <2.9.0'
+  # This must remain a tight upper bound constraint until nnbd is stable
+  sdk: '>=2.9.0-18.0 <2.10.0'
 
 dev_dependencies:
   test: "^1.6.0"
@@ -14,17 +13,11 @@ dev_dependencies:
 
 dependency_overrides:
   async:
-    git:
-      url: git://github.com/dart-lang/async.git
-      ref: null_safety
+    git: git://github.com/dart-lang/async.git
   boolean_selector:
-    git:
-      url: git://github.com/dart-lang/boolean_selector.git
-      ref: null_safety
+    git: git://github.com/dart-lang/boolean_selector.git
   charcode:
-    git:
-      url: git://github.com/dart-lang/charcode.git
-      ref: null_safety
+    git: git://github.com/dart-lang/charcode.git
   collection:
     git: git://github.com/dart-lang/collection.git
   js:
@@ -32,65 +25,42 @@ dependency_overrides:
       url: git://github.com/dart-lang/sdk.git
       path: pkg/js
   matcher:
-    git:
-      url: git://github.com/dart-lang/matcher.git
-      ref: null_safety
+    git: git://github.com/dart-lang/matcher.git
   meta:
     git:
       url: git://github.com/dart-lang/sdk.git
       path: pkg/meta
   path:
-    git:
-      url: git://github.com/dart-lang/path.git
-      ref: null_safety
+    git: git://github.com/dart-lang/path.git
   pedantic:
-    git:
-      url: git://github.com/dart-lang/pedantic.git
-      ref: null_safety
+    git: git://github.com/dart-lang/pedantic.git
   pool:
-    git:
-      url: git://github.com/dart-lang/pool.git
-      ref: null_safety
+    git: git://github.com/dart-lang/pool.git
   source_maps:
-    git:
-      url: git://github.com/dart-lang/source_maps.git
-      ref: null_safety
+    git: git://github.com/dart-lang/source_maps.git
   source_map_stack_trace:
-    git:
-      url: git://github.com/dart-lang/source_map_stack_trace.git
-      ref: null_safety
+    git: git://github.com/dart-lang/source_map_stack_trace.git
   source_span:
-    git:
-      url: git://github.com/dart-lang/source_span.git
-      ref: null_safety
+    git: git://github.com/dart-lang/source_span.git
   stack_trace:
-    git:
-      url: git://github.com/dart-lang/stack_trace.git
-      ref: null_safety
+    git: git://github.com/dart-lang/stack_trace.git
   stream_channel:
-    git:
-      url: git://github.com/dart-lang/stream_channel.git
-      ref: null_safety
+    git: git://github.com/dart-lang/stream_channel.git
   string_scanner:
-    git:
-      url: git://github.com/dart-lang/string_scanner.git
-      ref: null_safety
+    git: git://github.com/dart-lang/string_scanner.git
   term_glyph:
-    git:
-      url: git://github.com/dart-lang/term_glyph.git
-      ref: null_safety
+    git: git://github.com/dart-lang/term_glyph.git
   test_api:
     git:
       url: git://github.com/dart-lang/test.git
-      ref: null_safety
       path: pkgs/test_api
   test_core:
     git:
       url: git://github.com/dart-lang/test.git
-      ref: null_safety
       path: pkgs/test_core
   test:
     git:
       url: git://github.com/dart-lang/test.git
-      ref: null_safety
       path: pkgs/test
+  typed_data:
+    git: git://github.com/dart-lang/typed_data.git

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://www.github.com/dart-lang/characters
 
 environment:
   # This must remain a tight upper bound constraint until nnbd is stable
-  sdk: '>=2.9.0-18.0 <2.9.10'
+  sdk: '>=2.9.0-18.0 <=2.9.10'
 
 dev_dependencies:
   test: "^1.6.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://www.github.com/dart-lang/characters
 
 environment:
   # This must remain a tight upper bound constraint until nnbd is stable
-  sdk: '>=2.9.0-18.0 <2.10.0'
+  sdk: '>=2.9.0-18.0 <2.9.10'
 
 dev_dependencies:
   test: "^1.6.0"


### PR DESCRIPTION
This will be published and depended on by flutter in a cherry pick for the 2.9.x stable release 