### PR TITLE
update to the 2.10 dev sdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,32 @@
 language: dart
 dart:
-- 2.10.0-0.2-dev
+- preview/raw/2.10.0-0.2-dev
 
 jobs:
   include:
     - stage: analyze_and_format
       name: "Analyze lib/ (no experiment flag)"
-      dart: 2.10.0-0.2-dev
+      dart: preview/raw/2.10.0-0.2-dev
       os: linux
       script: dartanalyzer --fatal-warnings --fatal-infos lib/
     - stage: analyze_and_format
       name: "Analyze (with experiment flag)"
-      dart: 2.10.0-0.2-dev
+      dart: preview/raw/2.10.0-0.2-dev
       os: linux
       script: dartanalyzer --enable-experiment=non-nullable --fatal-warnings --fatal-infos .
     - stage: analyze_and_format
       name: "Format"
-      dart: 2.10.0-0.2-dev
+      dart: preview/raw/2.10.0-0.2-dev
       os: linux
       script: dartfmt -n --set-exit-if-changed .
     - stage: test
       name: "Vm Tests"
-      dart: 2.10.0-0.2-dev
+      dart: preview/raw/2.10.0-0.2-dev
       os: linux
       script: pub run --enable-experiment=non-nullable test -p vm
     - stage: test
       name: "Web Tests"
-      dart: 2.10.0-0.2-dev
+      dart: preview/raw/2.10.0-0.2-dev
       os: linux
       script: pub run --enable-experiment=non-nullable test -p chrome
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,37 +1,37 @@
 language: dart
 dart:
-- dev
+- 2.10.0-0.2-dev
 
 jobs:
   include:
     - stage: analyze_and_format
       name: "Analyze lib/ (no experiment flag)"
-      dart: dev
+      dart: 2.10.0-0.2-dev
       os: linux
       script: dartanalyzer --fatal-warnings --fatal-infos lib/
     - stage: analyze_and_format
       name: "Analyze (with experiment flag)"
-      dart: dev
+      dart: 2.10.0-0.2-dev
       os: linux
       script: dartanalyzer --enable-experiment=non-nullable --fatal-warnings --fatal-infos .
     - stage: analyze_and_format
       name: "Format"
-      dart: dev
+      dart: 2.10.0-0.2-dev
       os: linux
       script: dartfmt -n --set-exit-if-changed .
     - stage: test
       name: "Vm Tests"
-      dart: dev
+      dart: 2.10.0-0.2-dev
       os: linux
       script: pub run --enable-experiment=non-nullable test -p vm
     - stage: test
       name: "Web Tests"
-      dart: dev
+      dart: 2.10.0-0.2-dev
       os: linux
       script: pub run --enable-experiment=non-nullable test -p chrome
 
 branches:
-  only: [master, null_safety]
+  only: [master]
 
 cache:
   directories:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.0-nullsafety.2
+
+* Update for the 2.10 dev sdk.
+
+
 ## 1.1.0-nullsafety.1
 
 * Allow the <=2.9.10 stable sdks.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,12 +24,14 @@ dependency_overrides:
     git:
       url: git://github.com/dart-lang/sdk.git
       path: pkg/js
+      ref: 2-10-pkgs
   matcher:
     git: git://github.com/dart-lang/matcher.git
   meta:
     git:
       url: git://github.com/dart-lang/sdk.git
       path: pkg/meta
+      ref: 2-10-pkgs
   path:
     git: git://github.com/dart-lang/path.git
   pedantic:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: characters
-version: 1.1.0-nullsafety.1
+version: 1.1.0-nullsafety.2
 description: String replacement with operations that are Unicode/grapheme cluster aware.
 homepage: https://www.github.com/dart-lang/characters
 
 environment:
-  # This must remain a tight upper bound constraint until nnbd is stable
-  sdk: '>=2.9.0-18.0 <=2.9.10'
+  # This must remain a tight constraint until nnbd is stable
+  sdk: '>=2.10.0-0 <2.10.0'
 
 dev_dependencies:
   test: "^1.6.0"


### PR DESCRIPTION
This is in preparation for the actual 2.10 dev sdk release. This package needs to be published and pinned in flutter simultaneously with that release.

The tests are going to be failing until we update all transitive deps in a similar fashion (they need to declare a 2.10 language version).

The plan for lack of a better option is to just do these all as quickly as possible (and merge them into master), and then go re-run the travis jobs to get the build green again afterwords.