### PR TITLE
Prepare for the 2.11 dev SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.2.0-nullsafety
+## 1.1.0-nullsafety.3
 
 * Added `stringBeforeLength` and `stringAfterLength` to `CharacterRange`.
 * Added `CharacterRange.at` constructor.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0-nullsafety.3
+
+* Allow the 2.10 stable SDK.
+
 ## 1.1.0-nullsafety.2
 
 * Update for the 2.10 dev sdk.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: characters
-version: 1.2.0-nullsafety
+version: 1.1.0-nullsafety.3
 description: String replacement with operations that are Unicode/grapheme cluster aware.
 homepage: https://www.github.com/dart-lang/characters
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: characters
-version: 1.1.0-nullsafety.2
+version: 1.1.0-nullsafety.3
 description: String replacement with operations that are Unicode/grapheme cluster aware.
 homepage: https://www.github.com/dart-lang/characters
 
 environment:
   # This must remain a tight constraint until nnbd is stable
-  sdk: '>=2.10.0-0 <2.10.0'
+  sdk: '>=2.10.0-0 <2.11.0'
 
 dev_dependencies:
   test: "^1.6.0"


### PR DESCRIPTION
Bump the upper bound to allow 2.10 stable and 2.11.0 dev SDK versions.