### PR TITLE
Allow the 2.12 dev SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0-nullsafety.4
+
+* Allow the 2.12 dev SDKs.
+
 ## 1.1.0-nullsafety.3
 
 * Added `stringBeforeLength` and `stringAfterLength` to `CharacterRange`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,68 +1,12 @@
 name: characters
-version: 1.1.0-nullsafety.3
+version: 1.1.0-nullsafety.4
 description: String replacement with operations that are Unicode/grapheme cluster aware.
 homepage: https://www.github.com/dart-lang/characters
 
 environment:
   # This must remain a tight constraint until nnbd is stable
-  sdk: '>=2.10.0-110 <2.11.0'
+  sdk: '>=2.10.0-110 <2.12.0'
 
 dev_dependencies:
-  test: ^1.6.0
-  pedantic: ^1.9.0
-
-dependency_overrides:
-  async:
-    git: git://github.com/dart-lang/async.git
-  boolean_selector:
-    git: git://github.com/dart-lang/boolean_selector.git
-  charcode:
-    git: git://github.com/dart-lang/charcode.git
-  collection:
-    git: git://github.com/dart-lang/collection.git
-  js:
-    git:
-      url: git://github.com/dart-lang/sdk.git
-      path: pkg/js
-      ref: 2-10-pkgs
-  matcher:
-    git: git://github.com/dart-lang/matcher.git
-  meta:
-    git:
-      url: git://github.com/dart-lang/sdk.git
-      path: pkg/meta
-      ref: 2-10-pkgs
-  path:
-    git: git://github.com/dart-lang/path.git
-  pedantic:
-    git: git://github.com/dart-lang/pedantic.git
-  pool:
-    git: git://github.com/dart-lang/pool.git
-  source_maps:
-    git: git://github.com/dart-lang/source_maps.git
-  source_map_stack_trace:
-    git: git://github.com/dart-lang/source_map_stack_trace.git
-  source_span:
-    git: git://github.com/dart-lang/source_span.git
-  stack_trace:
-    git: git://github.com/dart-lang/stack_trace.git
-  stream_channel:
-    git: git://github.com/dart-lang/stream_channel.git
-  string_scanner:
-    git: git://github.com/dart-lang/string_scanner.git
-  term_glyph:
-    git: git://github.com/dart-lang/term_glyph.git
-  test_api:
-    git:
-      url: git://github.com/dart-lang/test.git
-      path: pkgs/test_api
-  test_core:
-    git:
-      url: git://github.com/dart-lang/test.git
-      path: pkgs/test_core
-  test:
-    git:
-      url: git://github.com/dart-lang/test.git
-      path: pkgs/test
-  typed_data:
-    git: git://github.com/dart-lang/typed_data.git
+  test: ^1.16.0-nullsafety
+  pedantic: ^1.10.0-nullsafety


### PR DESCRIPTION
Also bump deps to the `-nullsafety` versions and remove the dependency
overrides.