### PR TITLE
Bump SDK constraints for pub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.0-nullsafety.5
+
+* Use 2.12.0-0 lower bound and 3.0.0 upper bound SDK to work around pub
+  limitations.
+
 ## 1.1.0-nullsafety.4
 
 * Allow the 2.12 dev SDKs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.1.0-nullsafety.5
 
-* Use 2.12.0-0 lower bound and 3.0.0 upper bound SDK to work around pub
-  limitations.
+* Update sdk constraints to `>=2.12.0-0 <3.0.0` based on beta release
+  guidelines.
 
 ## 1.1.0-nullsafety.4
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,10 @@
 name: characters
-version: 1.1.0-nullsafety.4
+version: 1.1.0-nullsafety.5
 description: String replacement with operations that are Unicode/grapheme cluster aware.
 homepage: https://www.github.com/dart-lang/characters
 
 environment:
-  # This must remain a tight constraint until nnbd is stable
-  sdk: '>=2.10.0-110 <2.12.0'
+  sdk: ">=2.12.0-0 <3.0.0"
 
 dev_dependencies:
   test: ^1.16.0-nullsafety


### PR DESCRIPTION
Use a 2.12.0 lower bound since pub does not understand allowed
experiments for earlier versions.

Use a 3.0.0 upper bound to avoid a warning in pub and to give some
flexibility in publishing for stable.