### PR TITLE
Change pubspec homepage to repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,36 +1,13 @@
+## 1.1.1-dev
+
 ## 1.1.0
 
 * Stable release for null safety.
-
-## 1.1.0-nullsafety.5
-
-* Update sdk constraints to `>=2.12.0-0 <3.0.0` based on beta release
-  guidelines.
-
-## 1.1.0-nullsafety.4
-
-* Allow the 2.12 dev SDKs.
-
-## 1.1.0-nullsafety.3
-
 * Added `stringBeforeLength` and `stringAfterLength` to `CharacterRange`.
 * Added `CharacterRange.at` constructor.
 * Added `getRange(start, end)` and `characterAt(pos)` to `Characters`
   as alternative to `.take(end).skip(start)` and `getRange(pos, pos + 1)`.
 * Change some positional parameter names from `other` to `characters`.
-* Allow the 2.10 stable SDK.
-
-## 1.1.0-nullsafety.2
-
-* Update for the 2.10 dev sdk.
-
-## 1.1.0-nullsafety.1
-
-* Allow the <=2.9.10 stable sdks.
-
-## 1.1.0-nullsafety
-
-* Make package null safe.
 
 ## 1.0.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: characters
-version: 1.1.0
+version: 1.1.1-dev
 description: String replacement with operations that are Unicode/grapheme cluster aware.
-homepage: https://www.github.com/dart-lang/characters
+repository: https://www.github.com/dart-lang/characters
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dev_dependencies:
-  test: ^1.16.0-nullsafety
-  pedantic: ^1.10.0-nullsafety
+  test: ^1.16.0
+  pedantic: ^1.10.0


### PR DESCRIPTION
Closes dart-lang/core#385

We are gradually standardizing on specifying the `repository` key.

Other cleanup:
- Collapse the null safety prerelease changelogs.
- Use a stable SDK constraint.
- Use stable dependency constraints.