### PR TITLE
Change argument type of `contains`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.2.0
+
+* Changes the argument type of `Characters.contains` to (covariant) `String`.
+  The implementation still accepts `Object?`, so it can be cast to
+  `Iterable<Object?>`, but you get warned if you try to call directly with a
+  non-`String`.
+
 ## 1.1.1-dev
 
 * Switched from using lints in package:pedantic to package:lints.

--- a/lib/src/characters.dart
+++ b/lib/src/characters.dart
@@ -48,15 +48,19 @@ abstract class Characters implements Iterable<String> {
   /// as well as controlling the iteration in more detail.
   CharacterRange get iteratorAtEnd;
 
-  /// Whether [other] is an element of this sequence of
-  /// others.
+  /// Whether [singleCharacterString] occurs in this
+  /// sequence of characters.
   ///
-  /// Returns false if [other] is not a string containing
-  /// a single character,
-  /// because then it is not a single element of this [Iterable]
-  /// of characters.
+  /// Returns true only if [singleCharacterString] is
+  /// a string containing a *single* character
+  /// and that character is one of the characters
+  /// in this character sequence, and false otherwise.
+  /// This behavior is inherited from `Iterable<String>`,
+  /// which is why it is not [Character] based.
+  /// Use [containsAll] for a method which acts like
+  /// [String.contains] for characters.
   @override
-  bool contains(Object? other);
+  bool contains(covariant String singleCharacterString);
 
   /// Whether this sequence of characters contains [other]
   /// as a subsequence.

--- a/lib/src/characters_impl.dart
+++ b/lib/src/characters_impl.dart
@@ -116,14 +116,16 @@ class StringCharacters extends Iterable<String> implements Characters {
   }
 
   @override
-  bool contains(Object? element) {
-    if (element is String) {
-      if (element.isEmpty) return false;
-      var next =
-          Breaks(element, 0, element.length, stateSoTNoBreak).nextBreak();
-      if (next != element.length) return false;
-      // [element] is single grapheme cluster.
-      return _indexOf(string, element, 0, string.length) >= 0;
+  // ignore: avoid_renaming_method_parameters
+  bool contains(Object? singleCharacterString) {
+    if (singleCharacterString is String) {
+      if (singleCharacterString.isEmpty) return false;
+      var next = Breaks(singleCharacterString, 0, singleCharacterString.length,
+              stateSoTNoBreak)
+          .nextBreak();
+      if (next != singleCharacterString.length) return false;
+      // [singleCharacterString] is single grapheme cluster.
+      return _indexOf(string, singleCharacterString, 0, string.length) >= 0;
     }
     return false;
   }

--- a/lib/src/characters_impl.dart
+++ b/lib/src/characters_impl.dart
@@ -115,16 +115,14 @@ class StringCharacters extends Iterable<String> implements Characters {
   @override
   // ignore: avoid_renaming_method_parameters
   bool contains(Object? singleCharacterString) {
-    if (singleCharacterString is String) {
-      if (singleCharacterString.isEmpty) return false;
-      var next = Breaks(singleCharacterString, 0, singleCharacterString.length,
-              stateSoTNoBreak)
-          .nextBreak();
-      if (next != singleCharacterString.length) return false;
-      // [singleCharacterString] is single grapheme cluster.
-      return _indexOf(string, singleCharacterString, 0, string.length) >= 0;
-    }
-    return false;
+    if (singleCharacterString is! String) return false;
+    if (singleCharacterString.isEmpty) return false;
+    var next = Breaks(singleCharacterString, 0, singleCharacterString.length,
+            stateSoTNoBreak)
+        .nextBreak();
+    if (next != singleCharacterString.length) return false;
+    // [singleCharacterString] is single grapheme cluster.
+    return _indexOf(string, singleCharacterString, 0, string.length) >= 0;
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: characters
-version: 1.1.1-dev
+version: 1.2.0
 description: String replacement with operations that are Unicode/grapheme cluster aware.
 repository: https://www.github.com/dart-lang/characters
 


### PR DESCRIPTION
Changes the argument type of `contains` to `String` (covariantly).
This only affects the interface, the implementation still accepts `Object?`
and can be safely cast to `Iterable<Object>`.
Documents `contains` better.