### PR TITLE
Fix method syntax in ReadMe example code 

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ String firstTagString(String source) {
 }
 
 // Using CharacterRange operations.
-Characters firstTagCharacters(Characters source) =>
+Characters firstTagCharacters(Characters source) {
   var range = source.findFirst("<".characters);
   if (range != null && range.moveUntil(">".characters)) {
     return range.currentCharacters;


### PR DESCRIPTION
The method was declared with an expression body but it ended with a `}`. So I fixed this by replacing the expression body symbol with a '{'. 