### PR TITLE
Don't duplicate work in `where`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.1
+
+* Fix `Characters.where` which unnecessarily did the iteration and test twice.
+
 ## 1.2.0
 
 * Adds `Characters.empty` constant and makes `Characters("")` return it.

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Characters firstTagCharacters(Characters source) {
 [Characters]: https://pub.dev/documentation/characters/latest/characters/Characters-class.html "Characters class"
 [Code Points]: https://unicode.org/glossary/#code_point "Unicode Code Point"
 [Code Units]: https://unicode.org/glossary/#code_unit "Unicode Code Units"
-[Glyphs]: http://unicode.org/glossary/#glyph "Unicode Glyphs"
+[Glyphs]: https://unicode.org/glossary/#glyph "Unicode Glyphs"
 [Grapheme Clusters]: https://unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries "Unicode (Extended) Grapheme Cluster"
 [Iterable]: https://api.dart.dev/stable/2.0.0/dart-core/Iterable-class.html	"Iterable class"
 [Runes]: https://api.dart.dev/stable/2.0.0/dart-core/Runes-class.html	"Runes class"

--- a/lib/src/characters_impl.dart
+++ b/lib/src/characters_impl.dart
@@ -303,7 +303,7 @@ class StringCharacters extends Iterable<String> implements Characters {
   Characters where(bool Function(String) test) {
     var string = super.where(test).join();
     if (string.isEmpty) return Characters.empty;
-    return StringCharacters(super.where(test).join());
+    return StringCharacters(string);
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: characters
-version: 1.2.0
+version: 1.2.1
 description: String replacement with operations that are Unicode/grapheme cluster aware.
 repository: https://www.github.com/dart-lang/characters
 


### PR DESCRIPTION
Fixes dart-lang/core#390