### PR TITLE
prep to publish 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.2.1-dev
+## 1.2.1
 
 * Update the value of the pubspec `repository` field.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-[![pub package](https://img.shields.io/pub/v/characters.svg)](https://pub.dev/packages/characters)
 [![Build Status](https://github.com/dart-lang/characters/workflows/Dart%20CI/badge.svg)](https://github.com/dart-lang/characters/actions?query=workflow%3A"Dart+CI"+branch%3Amaster)
+[![pub package](https://img.shields.io/pub/v/characters.svg)](https://pub.dev/packages/characters)
+[![package publisher](https://img.shields.io/pub/publisher/characters.svg)](https://pub.dev/packages/characters/publisher)
 
 [`Characters`][Characters] are strings viewed as
 sequences of **user-perceived character**s,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: characters
-version: 1.2.1-dev
+version: 1.2.1
 description: String replacement with operations that are Unicode/grapheme cluster aware.
 repository: https://github.com/dart-lang/characters
 


### PR DESCRIPTION
- prep to publish 1.2.1
- update markdown badges in the readme