### PR TITLE
Fix broken comment references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .dart_tool/
 .packages
 pubspec.lock
+doc/api/

--- a/lib/src/characters.dart
+++ b/lib/src/characters.dart
@@ -49,9 +49,9 @@ abstract class Characters implements Iterable<String> {
   /// Returns [CharacterRange] positioned after the last character
   /// of this [Characters].
   ///
-  /// Allows iterating the characters of [string] backwards
-  /// using [CharacterRange.movePrevious],
-  /// as well as controlling the iteration in more detail.
+  /// Allows iterating the characters of [string] backwards using
+  /// [CharacterRange.moveBack], as well as controlling the iteration in more
+  /// detail.
   CharacterRange get iteratorAtEnd;
 
   /// Whether [singleCharacterString] occurs in this
@@ -62,7 +62,7 @@ abstract class Characters implements Iterable<String> {
   /// and that character is one of the characters
   /// in this character sequence, and false otherwise.
   /// This behavior is inherited from `Iterable<String>`,
-  /// which is why it is not [Character] based.
+  /// which is why it is not [Characters]-based.
   /// Use [containsAll] for a method which acts like
   /// [String.contains] for characters.
   @override
@@ -390,8 +390,7 @@ abstract class CharacterRange implements Iterator<String> {
   /// The copy is in the exact same state as this iterator.
   /// Can be used to iterate the following characters more than once
   /// at the same time. To simply rewind an iterator, remember the
-  /// [start] or [end] position and use [reset] to reset the iterator
-  /// to that position.
+  /// start or end position and use reset the iterator to that position.
   CharacterRange copy();
 
   /// Whether the current range is empty.

--- a/lib/src/characters.dart
+++ b/lib/src/characters.dart
@@ -50,8 +50,8 @@ abstract class Characters implements Iterable<String> {
   /// of this [Characters].
   ///
   /// Allows iterating the characters of [string] backwards using
-  /// [CharacterRange.moveBack], as well as controlling the iteration in more
-  /// detail.
+  /// [CharacterRange.moveBack],
+  /// as well as controlling the iteration in more detail.
   CharacterRange get iteratorAtEnd;
 
   /// Whether [singleCharacterString] occurs in this

--- a/lib/src/characters_impl.dart
+++ b/lib/src/characters_impl.dart
@@ -464,15 +464,15 @@ class StringCharacterRange implements CharacterRange {
 
   /// Creates a [Breaks] from [_end] to `_string.length`.
   ///
-  /// Uses information stored in [_state] for cases where the next
-  /// character has already been seen.
+  /// Uses information stored in the state for cases where the next character
+  /// has already been seen.
   Breaks _breaksFromEnd() {
     return Breaks(_string, _end, _string.length, stateSoTNoBreak);
   }
 
   /// Creates a [Breaks] from string start to [_start].
   ///
-  /// Uses information stored in [_state] for cases where the previous
+  /// Uses information stored in the state for cases where the previous
   /// character has already been seen.
   BackBreaks _backBreaksFromStart() {
     return BackBreaks(_string, _start, 0, stateEoTNoBreak);

--- a/tool/src/atsp.dart
+++ b/tool/src/atsp.dart
@@ -12,7 +12,7 @@
 
 /// An asymmetric weighted complete graph.
 ///
-/// The vertices are identified by numbers 0 through [vertices] - 1.
+/// The vertices are identified by numbers 0 through [vertexCount] - 1.
 /// Edges are pairs of vertices.
 class Graph {
   /// Number of vertices.


### PR DESCRIPTION
These broken comment references are all highlighted by the `comment_references` linter rule, and the `dart doc` tool.

In a few cases, I tried to find a replacement, but I also had to just abandon some `[]` references as I could not tell what the current equivalent is, for what they (presumably) previously referred to.

Let me know if there is better replacement text. Let me know if I should bump the version in CHANGELOG and pubspec files.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
