### PR TITLE
Add `topics` to  `pubspec.yaml`

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,3 +10,11 @@ environment:
 dev_dependencies:
   dart_flutter_team_lints: ^1.0.0
   test: ^1.16.0
+
+topics:
+ - strings
+ - unicode
+
+
+ 
+ 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,17 +4,13 @@ description: >-
   String replacement with operations that are Unicode/grapheme cluster aware.
 repository: https://github.com/dart-lang/characters
 
+topics:
+ - strings
+ - unicode
+
 environment:
   sdk: ">=2.19.0 <4.0.0"
 
 dev_dependencies:
   dart_flutter_team_lints: ^1.0.0
   test: ^1.16.0
-
-topics:
- - strings
- - unicode
-
-
- 
- 


### PR DESCRIPTION
Topics helps users on pub.dev discover packages, and related packages.

You can see a list of [topics here](https://pub.dev/topics).
You can also make your own topics.

Topics are added to pubspec.yaml as follows:
```
topics:
 - my-topic
 - some-other-topic
```
See also: https://dart.dev/tools/pub/pubspec#topics